### PR TITLE
Flips comparison operator in time filters

### DIFF
--- a/Defender For Endpoint/AnomalousSMBSessionsCreated.md
+++ b/Defender For Endpoint/AnomalousSMBSessionsCreated.md
@@ -17,7 +17,7 @@ A actor has gotten access to a system en performs a scan to identify possible la
 ## Defender For Endpoint
 ```
 DeviceNetworkEvents
-| where Timestamp < ago(1h)
+| where Timestamp > ago(1h)
 | where RemotePort == 445
 | summarize
      TotalIpsAccessed = dcount(RemoteIP),
@@ -36,7 +36,7 @@ DeviceNetworkEvents
 ## Sentinel
 ```
 DeviceNetworkEvents
-| where TimeGenerated < ago(1h)
+| where TimeGenerated > ago(1h)
 | where RemotePort == 445
 | summarize
      TotalIpsAccessed = dcount(RemoteIP),

--- a/Defender For Endpoint/DevicesWithTheMostSMBSessions.md
+++ b/Defender For Endpoint/DevicesWithTheMostSMBSessions.md
@@ -15,7 +15,7 @@ let AllDomainControllers =
      | where LocalIPType == "FourToSixMapping"
      | summarize make_set(DeviceId);
 DeviceNetworkEvents
-| where Timestamp < ago(TimeFrame)
+| where Timestamp > ago(TimeFrame)
 | where RemotePort == 445
 | where not(DeviceId in (AllDomainControllers)) // THis is to reduce FP because of e.g. MDI, if you do not have MDI do not use this filter.
 | summarize TotalRemoteConnections = dcount(RemoteIP) by DeviceName
@@ -30,7 +30,7 @@ let AllDomainControllers =
      | where LocalIPType == "FourToSixMapping"
      | summarize make_set(DeviceId);
 DeviceNetworkEvents
-| where TimeGenerated < ago(TimeFrame)
+| where TimeGenerated > ago(TimeFrame)
 | where RemotePort == 445
 | where not(DeviceId in (AllDomainControllers)) // This is to reduce FP because of e.g. MDI, if you do not have MDI do not use this filter.
 | summarize TotalRemoteConnections = dcount(RemoteIP) by DeviceName

--- a/Defender For Endpoint/SMBSessionsByDevice.md
+++ b/Defender For Endpoint/SMBSessionsByDevice.md
@@ -5,7 +5,7 @@
 let TimeFrame = 24h; //Customizable h = hours, d = days
 let SuspiciousDevices = dynamic(['server1.com', 'laptop1.com']);
 DeviceNetworkEvents
-| where Timestamp < ago(TimeFrame)
+| where Timestamp > ago(TimeFrame)
 | where RemotePort == 445
 | where ActionType  == "ConnectionSuccess"
 | where DeviceName in~ (SuspiciousDevices)
@@ -16,7 +16,7 @@ DeviceNetworkEvents
 let TimeFrame = 24h; //Customizable h = hours, d = days
 let SuspiciousDevices = dynamic(['server1.com', 'laptop1.com']);
 DeviceNetworkEvents
-| where TimeGenerated < ago(TimeFrame)
+| where TimeGenerated > ago(TimeFrame)
 | where RemotePort == 445
 | where ActionType == "ConnectionSuccess"
 | where DeviceName in~ (SuspiciousDevices)

--- a/Defender For Endpoint/SMBSessionsByFileName.md
+++ b/Defender For Endpoint/SMBSessionsByFileName.md
@@ -4,7 +4,7 @@
 ```
 let TimeFrame = 24h; //Customizable h = hours, d = days
 DeviceNetworkEvents
-| where Timestamp < ago(TimeFrame)
+| where Timestamp > ago(TimeFrame)
 | where RemotePort == 445
 | where InitiatingProcessFileName <> "Microsoft.Tri.Sensor.exe" // MDI Sensor
 | where InitiatingProcessFileName <> "sensendr.exe" // MDE Device Discovery
@@ -14,7 +14,7 @@ DeviceNetworkEvents
 ```
 let TimeFrame = 24h; //Customizable h = hours, d = days
 DeviceNetworkEvents
-| where TimeGenerated < ago(TimeFrame)
+| where TimeGenerated > ago(TimeFrame)
 | where RemotePort == 445
 | where InitiatingProcessFileName <> "Microsoft.Tri.Sensor.exe" // MDI Sensor
 | where InitiatingProcessFileName <> "sensendr.exe" // MDE Device Discovery

--- a/Defender For Endpoint/SMBSessionsGeneratedByFile.md
+++ b/Defender For Endpoint/SMBSessionsGeneratedByFile.md
@@ -4,7 +4,7 @@
 ```
 let TimeFrame = 24h; //Customizable h = hours, d = days
 DeviceNetworkEvents
-| where Timestamp < ago(TimeFrame)
+| where Timestamp > ago(TimeFrame)
 | where RemotePort == 445
 | where InitiatingProcessFileName <> "Microsoft.Tri.Sensor.exe" // MDI Sensor
 | where InitiatingProcessFileName <> "sensendr.exe" // MDE Device Discovery
@@ -14,7 +14,7 @@ DeviceNetworkEvents
 ```
 let TimeFrame = 24h; //Customizable h = hours, d = days
 DeviceNetworkEvents
-| where TimeGenerated < ago(TimeFrame)
+| where TimeGenerated > ago(TimeFrame)
 | where RemotePort == 445
 | where InitiatingProcessFileName <> "Microsoft.Tri.Sensor.exe" // MDI Sensor
 | where InitiatingProcessFileName <> "sensendr.exe" // MDE Device Discovery

--- a/Threat Hunting Cases/Suspicious SMB Sessions.md
+++ b/Threat Hunting Cases/Suspicious SMB Sessions.md
@@ -15,7 +15,7 @@ let AllDomainControllers =
      | where LocalIPType == "FourToSixMapping"
      | summarize make_set(DeviceId);
 DeviceNetworkEvents
-| where Timestamp  < ago(TimeFrame)
+| where Timestamp  > ago(TimeFrame)
 | where RemotePort == 445
 | where not(DeviceId in (AllDomainControllers)) // THis is to reduce FP because of e.g. MDI, if you do not have MDI do not use this filter.
 | summarize TotalRemoteConnections = dcount(RemoteIP) by DeviceName
@@ -30,7 +30,7 @@ let AllDomainControllers =
      | where LocalIPType == "FourToSixMapping"
      | summarize make_set(DeviceId);
 DeviceNetworkEvents
-| where TimeGenerated < ago(TimeFrame)
+| where TimeGenerated > ago(TimeFrame)
 | where RemotePort == 445
 | where not(DeviceId in (AllDomainControllers)) // This is to reduce FP because of e.g. MDI, if you do not have MDI do not use this filter.
 | summarize TotalRemoteConnections = dcount(RemoteIP) by DeviceName
@@ -45,7 +45,7 @@ In Windows some files are known to set up benign SMB sessions or to map shares. 
 ```
 let TimeFrame = 24h; //Customizable h = hours, d = days
 DeviceNetworkEvents
-| where Timestamp < ago(TimeFrame)
+| where Timestamp > ago(TimeFrame)
 | where RemotePort == 445
 | where InitiatingProcessFileName <> "Microsoft.Tri.Sensor.exe" // MDI Sensor
 | where InitiatingProcessFileName <> "sensendr.exe" // MDE Device Discovery
@@ -55,7 +55,7 @@ DeviceNetworkEvents
 ```
 let TimeFrame = 24h; //Customizable h = hours, d = days
 DeviceNetworkEvents
-| where TimeGenerated < ago(TimeFrame)
+| where TimeGenerated > ago(TimeFrame)
 | where RemotePort == 445
 | where InitiatingProcessFileName <> "Microsoft.Tri.Sensor.exe" // MDI Sensor
 | where InitiatingProcessFileName <> "sensendr.exe" // MDE Device Discovery
@@ -73,7 +73,7 @@ Based on the output of step 2, the files that seem suspicious can be added to th
 let TimeFrame = 24h; //Customizable h = hours, d = days
 let FileNames = dynamic(['nmap.exe', 'bloodhound.exe']); // Add your own findings in the list, these are examples
 DeviceNetworkEvents
-| where Timestamp < ago(TimeFrame)
+| where Timestamp > ago(TimeFrame)
 | where RemotePort == 445
 | where InitiatingProcessFileName in~ (FileNames)
 | summarize CommandsExecuted = make_set(InitiatingProcessCommandLine) by DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName
@@ -84,7 +84,7 @@ DeviceNetworkEvents
 let TimeFrame = 24h; //Customizable h = hours, d = days
 let FileNames = dynamic(['nmap.exe', 'bloodhound.exe']); // Add your own findings in the list, these are examples
 DeviceNetworkEvents
-| where TimeGenerated < ago(TimeFrame)
+| where TimeGenerated > ago(TimeFrame)
 | where RemotePort == 445
 | where InitiatingProcessFileName in~ (FileNames)
 | summarize CommandsExecuted = make_set(InitiatingProcessCommandLine) by DeviceName, InitiatingProcessAccountDomain, InitiatingProcessAccountName
@@ -99,7 +99,7 @@ This step investigates all connections made by the devices that have created sus
 let TimeFrame = 24h; //Customizable h = hours, d = days
 let SuspiciousDevices = dynamic(['server1.com', 'laptop1.com']);
 DeviceNetworkEvents
-| where Timestamp < ago(TimeFrame)
+| where Timestamp > ago(TimeFrame)
 | where RemotePort == 445
 | where ActionType  == "ConnectionSuccess"
 | where DeviceName in~ (SuspiciousDevices)
@@ -110,7 +110,7 @@ DeviceNetworkEvents
 let TimeFrame = 24h; //Customizable h = hours, d = days
 let SuspiciousDevices = dynamic(['server1.com', 'laptop1.com']);
 DeviceNetworkEvents
-| where TimeGenerated < ago(TimeFrame)
+| where TimeGenerated > ago(TimeFrame)
 | where RemotePort == 445
 | where ActionType == "ConnectionSuccess"
 | where DeviceName in~ (SuspiciousDevices)


### PR DESCRIPTION
This PR flips the comparison operator in some of the SMB-related queries, otherwise the queries target all historic data except for in the defined timeframe.