### PR TITLE
Update LocalAccountCreated.md

### DIFF
--- a/Defender For Endpoint/LocalAccountCreated.md
+++ b/Defender For Endpoint/LocalAccountCreated.md
@@ -58,8 +58,7 @@ DeviceEvents
 | where ActionType == 'UserAccountCreated'
 // Extract the DeviceName without the domain name
 | extend DeviceNameWithoutDomain = extract(@'(.*?)\.', 1, DeviceName)
-// Filter on local additions, then the AccountDomain is equal on the 
-DeviceName
+// Filter on local additions, then the AccountDomain is equal on the DeviceName
 | where AccountDomain =~ DeviceNameWithoutDomain
 | project TimeGenerated, DeviceName, ActionType, AccountDomain, AccountName, AccountSid
 ```


### PR DESCRIPTION
"DeviceName" seems to be situated after a break line and hence if someone copy pastes the query it doesn't work. Proposed change places "DeviceName" at the end of the commentary line.