### PR TITLE
Update Curl-CVE-2023-38545.md

### DIFF
--- a/Vulnerability Management/Curl-CVE-2023-38545.md
+++ b/Vulnerability Management/Curl-CVE-2023-38545.md
@@ -14,7 +14,7 @@ let ProcessBasedDevices = DeviceProcessEvents
     | distinct DeviceId, DeviceName;
 DeviceTvmSoftwareInventory
 | where SoftwareName has "curl"
-| join kind=rightouter ProcessBasedDevices on DeviceId
+| join kind=fullouter ProcessBasedDevices on DeviceId
 | extend Method = iff(isempty(SoftwareVersion), "Process", "Software Inventory")
 | extend CombinedName = iff(isempty(DeviceName), DeviceName1, DeviceName)
 | extend CombinedId = iff(isempty(DeviceId), DeviceId1, DeviceId)


### PR DESCRIPTION
Previous query did not show devices w/ curl installed. Changed join type from rightouter to fullouter to include either/or