### PR TITLE
Add monitoring for cloud break glass accounts

### DIFF
--- a/Defender For Identity/MonitorCloudBreakGlassAccount.md
+++ b/Defender For Identity/MonitorCloudBreakGlassAccount.md
@@ -25,23 +25,6 @@ AADSignInEventsBeta
      AccountObjectId,
      AccountUpn
 ```
-## Sentinel
-```
-AADSignInEventsBeta
-| where AccountDisplayName  == "Input display name of account here"
-| project AccountDisplayName,
-     Country,
-     IPAddress,
-     Timestamp,
-     Application,
-     DeviceName,
-     ReportId,
-     LogonType,
-     SessionId,
-     OSPlatform,
-     AccountObjectId,
-     AccountUpn
-```
 
 
 

--- a/Defender For Identity/MonitorCloudBreakGlassAccount.md
+++ b/Defender For Identity/MonitorCloudBreakGlassAccount.md
@@ -1,0 +1,47 @@
+# Detect when login is performed using a specified account (Cloud break glass account)
+
+## Query Information
+
+#### Description
+It is best practice to have break glass accounts, which are excluded from all conditional access policies. To monitor all login activities under a specified account, this Detection Rule can be used. If any activity is performed using the specified account, an alert will be generated.
+
+#### Risk
+If an attacker could get access to a break glass account, this account could be used to bypass all conditional access rules, and get unrestricted access to the environment.
+
+## Defender For Endpoint
+```
+AADSignInEventsBeta
+| where AccountDisplayName  == "Input display name of account here"
+| project AccountDisplayName,
+     Country,
+     IPAddress,
+     Timestamp,
+     Application,
+     DeviceName,
+     ReportId,
+     LogonType,
+     SessionId,
+     OSPlatform,
+     AccountObjectId,
+     AccountUpn
+```
+## Sentinel
+```
+AADSignInEventsBeta
+| where AccountDisplayName  == "Input display name of account here"
+| project AccountDisplayName,
+     Country,
+     IPAddress,
+     Timestamp,
+     Application,
+     DeviceName,
+     ReportId,
+     LogonType,
+     SessionId,
+     OSPlatform,
+     AccountObjectId,
+     AccountUpn
+```
+
+
+


### PR DESCRIPTION
Hey there
This detection rule would be able to detect if any activity is performed from a cloud break glass account. this helps to monitor any activities performed by these accounts.